### PR TITLE
Allow Swiftmailer v6 since Laravel 5.5 requires it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.5.0",
         "illuminate/support": "~5.1.10|5.2.*|5.3.*|5.4.*|5.5.*",
-        "swiftmailer/swiftmailer": "~5.1"
+        "swiftmailer/swiftmailer": "~5.1|~6.0"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.1",


### PR DESCRIPTION
Fixes #34.